### PR TITLE
fix(AITK-346): Add example count to GET /accuracy endpoint

### DIFF
--- a/Zuva DocAI.postman_collection.json
+++ b/Zuva DocAI.postman_collection.json
@@ -2,7 +2,8 @@
 	"info": {
 		"_postman_id": "12615108-3f98-4237-b8bd-2b1840519119",
 		"name": "Zuva DocAI",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "8497264"
 	},
 	"item": [
 		{
@@ -1684,6 +1685,7 @@
 									"    pm.expect(jsonData).to.have.property(\"f_score\");",
 									"    pm.expect(jsonData).to.have.property(\"precision\");",
 									"    pm.expect(jsonData).to.have.property(\"recall\");",
+									"    pm.expect(jsonData).to.have.property(\"example_count\");",
 									"});"
 								],
 								"type": "text/javascript"
@@ -1728,7 +1730,7 @@
 							"_postman_previewlanguage": "json",
 							"header": [],
 							"cookie": [],
-							"body": "{\n    \"f_score\": 0.95,\n    \"precision\": 0.9,\n    \"recall\": 1\n}"
+							"body": "{\n    \"f_score\": 0.95,\n    \"precision\": 0.9,\n    \"recall\": 1,\n    \"example_count\": 73\n}"
 						},
 						{
 							"name": "Get Field Accuracy Not Found",


### PR DESCRIPTION
Add example count test to the GET /accuracy endpoint and example response for GET /accuracy with example count.
